### PR TITLE
Allow dimensions to start at values other than 1

### DIFF
--- a/src/binary.jl
+++ b/src/binary.jl
@@ -6,6 +6,7 @@ function Writer{binary}(
     labels::Vector{String},
     time_dimension::String,
     dimension_size::Vector{Int},
+    dimension_offset::Vector{Int} = ones(Int, length(dimension_size)),
     remove_if_exists::Bool = true,
     fill_with_nan::Bool = true,
     kwargs...,
@@ -17,6 +18,7 @@ function Writer{binary}(
         dimensions = dimensions,
         time_dimension = time_dimension,
         dimension_size = dimension_size,
+        dimension_offset = dimension_offset,
         labels = labels,
         kwargs...,
     )
@@ -171,13 +173,14 @@ function convert(
         labels = metadata.labels,
         time_dimension = String(metadata.time_dimension),
         dimension_size = metadata.dimension_size,
+        dimension_offset = metadata.dimension_offset,
         initial_date = metadata.initial_date,
         unit = metadata.unit,
     )
 
-    dims = Quiver.first_position!(metadata.dimension_size)
+    dims = Quiver.first_position!(metadata.dimension_size, metadata.dimension_offset)
     for _ in 1:prod(metadata.dimension_size)
-        Quiver.next_dim!(dims, metadata.dimension_size)
+        Quiver.next_dim!(dims, metadata.dimension_size, metadata.dimension_offset)
         Quiver.goto!(reader, dims...)
         if all(isnan.(reader.data))
             continue

--- a/src/csv.jl
+++ b/src/csv.jl
@@ -12,6 +12,7 @@ function Writer{csv}(
     labels::Vector{String},
     time_dimension::String,
     dimension_size::Vector{Int},
+    dimension_offset::Vector{Int} = ones(Int, length(dimension_size)),
     remove_if_exists::Bool = true,
     kwargs...,
 )
@@ -22,6 +23,7 @@ function Writer{csv}(
         dimensions = dimensions,
         time_dimension = time_dimension,
         dimension_size = dimension_size,
+        dimension_offset = dimension_offset,
         labels = labels,
         kwargs...,
     )
@@ -212,6 +214,7 @@ function convert(
         labels = metadata.labels,
         time_dimension = String(metadata.time_dimension),
         dimension_size = metadata.dimension_size,
+        dimension_offset = metadata.dimension_offset,
         initial_date = metadata.initial_date,
         unit = metadata.unit,
     )

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -51,15 +51,16 @@ function merge(
         dimensions = string.(metadata.dimensions),
         time_dimension = string(metadata.time_dimension),
         dimension_size = metadata.dimension_size,
+        dimension_offset = metadata.dimension_offset,
         initial_date = metadata.initial_date,
         unit = metadata.unit,
     )
 
-    dims = Quiver.first_position!(metadata.dimension_size)
+    dims = Quiver.first_position!(metadata.dimension_size, metadata.dimension_offset)
     num_labels = [length(reader.metadata.labels) for reader in readers]
     data = zeros(sum(num_labels))
     for _ in 1:prod(metadata.dimension_size)
-        Quiver.next_dim!(dims, metadata.dimension_size)
+        Quiver.next_dim!(dims, metadata.dimension_size, metadata.dimension_offset)
         for (i, reader) in enumerate(readers)
             Quiver.goto!(reader, dims...)
             if i == 1

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -13,6 +13,8 @@ mutable struct Metadata
     unit::String
     # Maximum index for each dimension
     dimension_size::Vector{Int}
+    # Starting value for each dimension (e.g., [2025, 1, 1] for year starting at 2025)
+    dimension_offset::Vector{Int}
     # Number of time series in the same file
     number_of_time_series::Int
     # Names of the time series
@@ -37,6 +39,7 @@ function Metadata(;
     time_dimension::String,
     unit::String = "",
     dimension_size::Vector{Int},
+    dimension_offset::Vector{Int} = ones(Int, length(dimension_size)),
     labels::Vector{String},
 )
     metadata = Metadata(
@@ -47,6 +50,7 @@ function Metadata(;
         Symbol(time_dimension),
         unit,
         dimension_size,
+        dimension_offset,
         length(labels),
         labels,
         QUIVER_FILE_VERSION,
@@ -62,6 +66,7 @@ function to_ordered_dict(metadata::Metadata)
         "version" => metadata.version,
         "dimensions" => String.(metadata.dimensions),
         "dimension_size" => metadata.dimension_size,
+        "dimension_offset" => metadata.dimension_offset,
         "initial_date" => Dates.format(metadata.initial_date, "yyyy-mm-dd HH:MM:SS"),
         "time_dimension" => String(metadata.time_dimension),
         "frequency" => metadata.frequency,
@@ -81,6 +86,8 @@ end
 
 function from_toml(filename::String)
     dict_metadata = TOML.parsefile(filename)
+    # For backward compatibility, if dimension_offset is not present, default to ones
+    dimension_offset = get(dict_metadata, "dimension_offset", ones(Int, length(dict_metadata["dimension_size"])))
     metadata = Metadata(
         frequency = dict_metadata["frequency"],
         initial_date = Dates.DateTime(dict_metadata["initial_date"], "yyyy-mm-dd HH:MM:SS"),
@@ -88,6 +95,7 @@ function from_toml(filename::String)
         time_dimension = dict_metadata["time_dimension"],
         unit = dict_metadata["unit"],
         dimension_size = dict_metadata["dimension_size"],
+        dimension_offset = dimension_offset,
         labels = dict_metadata["labels"],
     )
     validate_metadata(metadata)
@@ -105,6 +113,13 @@ function validate_metadata(metadata::Metadata)
     if metadata.number_of_dimensions != length(metadata.dimension_size)
         @error(
             "The number_of_dimensions ($(metadata.number_of_dimensions)) must be equal to the length of dimension_size ($(metadata.dimension_size))."
+        )
+        num_errors += 1
+    end
+
+    if metadata.number_of_dimensions != length(metadata.dimension_offset)
+        @error(
+            "The number_of_dimensions ($(metadata.number_of_dimensions)) must be equal to the length of dimension_offset ($(metadata.dimension_offset))."
         )
         num_errors += 1
     end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -53,17 +53,18 @@ function apply_expression(
         dimensions = string.(dimensions),
         time_dimension = string(metadata.time_dimension),
         dimension_size = metadata.dimension_size,
+        dimension_offset = metadata.dimension_offset,
         initial_date = metadata.initial_date,
         unit = metadata.unit,
         frequency = metadata.frequency,
     )
 
-    dims = Quiver.first_position!(metadata.dimension_size)
+    dims = Quiver.first_position!(metadata.dimension_size, metadata.dimension_offset)
 
     index_of_labels_all_readers = [findall(x -> x in reader.metadata.labels, labels) for reader in readers]
     data_all_readers = [zeros(num_labels) for _ in 1:n_readers]
     for _ in 1:prod(metadata.dimension_size)
-        Quiver.next_dim!(dims, metadata.dimension_size)
+        Quiver.next_dim!(dims, metadata.dimension_size, metadata.dimension_offset)
         for (i, reader) in enumerate(readers)
             Quiver.goto!(reader, dims...)
             data_all_readers[i][index_of_labels_all_readers[i]] = Float64.(reader.data)
@@ -118,6 +119,7 @@ function apply_expression_over_dimension(
     all_idxs = 1:length(dimensions)
     other_dims_idx = filter(i -> i != dim_to_operate_idx, all_idxs)
     other_dimension_sizes = dimension_size[other_dims_idx]
+    other_dimension_offsets = metadata.dimension_offset[other_dims_idx]
 
     writer = Quiver.Writer{impl}(
         output_filename;
@@ -125,6 +127,7 @@ function apply_expression_over_dimension(
         dimensions = string.(dimensions[other_dims_idx]),
         time_dimension = string(metadata.time_dimension),
         dimension_size = other_dimension_sizes,
+        dimension_offset = other_dimension_offsets,
         initial_date = metadata.initial_date,
         unit = metadata.unit,
         frequency = metadata.frequency,
@@ -132,13 +135,14 @@ function apply_expression_over_dimension(
 
     dims_operate = Vector{Int}(undef, length(dimensions))
     data = zeros(length(labels), dimension_size[dim_to_operate_idx])
-    dims = Quiver.first_position!(other_dimension_sizes)
+    dims = Quiver.first_position!(other_dimension_sizes, other_dimension_offsets)
+    dim_operate_offset = metadata.dimension_offset[dim_to_operate_idx]
     for _ in 1:prod(other_dimension_sizes)
-        Quiver.next_dim!(dims, other_dimension_sizes)
+        Quiver.next_dim!(dims, other_dimension_sizes, other_dimension_offsets)
         dims_operate[other_dims_idx] .= dims
 
         for i in 1:dimension_size[dim_to_operate_idx]
-            dims_operate[dim_to_operate_idx] = i
+            dims_operate[dim_to_operate_idx] = dim_operate_offset + i - 1
             Quiver.goto!(reader, dims_operate...)
             data[:, i] = Float64.(reader.data)
         end
@@ -182,17 +186,18 @@ function apply_expression_over_agents(
         dimensions = string.(dimensions),
         time_dimension = string(metadata.time_dimension),
         dimension_size = dimension_size,
+        dimension_offset = metadata.dimension_offset,
         initial_date = metadata.initial_date,
         unit = metadata.unit,
         frequency = metadata.frequency,
     )
 
-    dims = Quiver.first_position!(dimension_size)
+    dims = Quiver.first_position!(dimension_size, metadata.dimension_offset)
 
     data = zeros(n_new_agents)
     # Iterate over all combinations of the other dimensions using column-major order
     for _ in 1:prod(dimension_size)
-        Quiver.next_dim!(dims, dimension_size)
+        Quiver.next_dim!(dims, dimension_size, metadata.dimension_offset)
         Quiver.goto!(reader, dims...)
         data = vcat(operation(reader.data))
         # Write the result to the output file

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -260,12 +260,14 @@ function file_to_array(
         dimension_sizes...,
     )
 
-    dims = Quiver.first_position!(metadata.dimension_size)
+    dims = Quiver.first_position!(metadata.dimension_size, metadata.dimension_offset)
 
     for _ in 1:prod(metadata.dimension_size)
-        Quiver.next_dim!(dims, metadata.dimension_size)
+        Quiver.next_dim!(dims, metadata.dimension_size, metadata.dimension_offset)
         Quiver.goto!(reader, dims...)
-        data[:, reverse(dims)...] = reader.data
+        # Convert dims from actual values to 1-based indices for array indexing
+        indices = dims .- metadata.dimension_offset .+ 1
+        data[:, reverse(indices)...] = reader.data
     end
 
     Quiver.close!(reader)
@@ -301,7 +303,7 @@ function file_to_df(
     metadata = reader.metadata
 
     df = DataFrame()
-    dims = Quiver.first_position!(metadata.dimension_size)
+    dims = Quiver.first_position!(metadata.dimension_size, metadata.dimension_offset)
 
     # Add all columns to the DataFrame
     for dim in metadata.dimensions
@@ -312,7 +314,7 @@ function file_to_df(
     end
 
     for _ in 1:prod(metadata.dimension_size)
-        Quiver.next_dim!(dims, metadata.dimension_size)
+        Quiver.next_dim!(dims, metadata.dimension_size, metadata.dimension_offset)
         Quiver.goto!(reader, dims...)
         if all(isnan.(reader.data))
             continue

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,13 +38,15 @@ end
 
 function next_dim!(
     current_dimensions::Vector{Int},
-    max_size_dmensions::Vector{Int},
+    max_size_dimensions::Vector{Int},
+    dimension_offset::Vector{Int},
 )
     for i in length(current_dimensions):-1:1
-        if current_dimensions[i] < max_size_dmensions[i]
+        max_value = dimension_offset[i] + max_size_dimensions[i] - 1
+        if current_dimensions[i] < max_value
             current_dimensions[i] += 1
             for j in i+1:length(current_dimensions)
-                current_dimensions[j] = 1
+                current_dimensions[j] = dimension_offset[j]
             end
             return
         end
@@ -52,10 +54,28 @@ function next_dim!(
     return
 end
 
+# Backward compatibility version
+function next_dim!(
+    current_dimensions::Vector{Int},
+    max_size_dimensions::Vector{Int},
+)
+    dimension_offset = ones(Int, length(max_size_dimensions))
+    return next_dim!(current_dimensions, max_size_dimensions, dimension_offset)
+end
+
+function first_position!(
+    max_size_dimensions::Vector{Int},
+    dimension_offset::Vector{Int},
+)
+    dims = copy(dimension_offset)
+    dims[end] = dimension_offset[end] - 1
+    return dims
+end
+
+# Backward compatibility version
 function first_position!(
     max_size_dimensions::Vector{Int},
 )
-    dims = fill(1, length(max_size_dimensions))
-    dims[end] = 0
-    return dims
+    dimension_offset = ones(Int, length(max_size_dimensions))
+    return first_position!(max_size_dimensions, dimension_offset)
 end


### PR DESCRIPTION
This change is important when an output has "year" as a dimension, allowing the dimension to start from a value such as 2020, rather than 1.
The code was entirely written by Claude.