### PR TITLE
Release v0.8.4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.executablePath": "${env:JULIA_1112}"
-}

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,17 +1,17 @@
 [[quiver]]
 arch = "x86_64"
-git-tree-sha1 = "83c5e605996658a51f2b0cd2037f11658c2204b2"
+git-tree-sha1 = "cb8b01355c22115d61ac39f5b2dcd949fd5cd241"
 libc = "glibc"
 os = "linux"
 
     [[quiver.download]]
-    sha256 = "62123f74e290a6883dcdf22a0eb38ddc8dfa66509a0040134816c990a3ea75a0"
-    url = "https://julia-artifacts.s3.amazonaws.com/quiver/0.8.3/quiver-linux-x86_64.tgz"
+    sha256 = "95123f95e62a4a6a02a52e1dccdfc23473c2e1302fdd4da1a5cc33d268218322"
+    url = "https://julia-artifacts.s3.amazonaws.com/quiver/0.8.4/quiver-linux-x86_64.tgz"
 [[quiver]]
 arch = "x86_64"
-git-tree-sha1 = "44bf6a4343a4664122d0fb556062d25f6943f914"
+git-tree-sha1 = "97ffb7249db526582e1bf45b08cd0831cb46a975"
 os = "windows"
 
     [[quiver.download]]
-    sha256 = "da3eebc16ed1bdc679882465135f5a3c302c71d2e87853334477c26f129c39e3"
-    url = "https://julia-artifacts.s3.amazonaws.com/quiver/0.8.3/quiver-windows-x86_64.tgz"
+    sha256 = "d356bbf7d80855c8bb4d2734614c9ff5f7e459957ca5221c21016ccb02db07b4"
+    url = "https://julia-artifacts.s3.amazonaws.com/quiver/0.8.4/quiver-windows-x86_64.tgz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Quiver"
 uuid = "cdbb3f72-2527-4dbd-9d0e-93533a5519ac"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/example2.jl
+++ b/example2.jl
@@ -1,0 +1,53 @@
+using Quiver
+
+data = [
+    1.0 2.0;
+    2.0 4.0;
+    3.0 8.0
+]
+
+@show rows = size(data, 1)
+
+md = Quiver.Binary.Metadata(;
+    initial_datetime = "2025-01-01T00:00:00",
+    unit = "MW",
+    labels = ["val1", "val2"],
+    dimensions = ["row"],
+    dimension_sizes = Int64[rows],
+)
+
+a = Quiver.Binary.open_file("a"; mode = 'w', metadata = md)
+for row in 1:rows
+    Quiver.Binary.write!(a; data = data[row, :], row = row)
+end
+Quiver.Binary.close!(a)
+
+b = Quiver.Binary.open_file("b"; mode = 'w', metadata = md)
+for row in 1:rows
+    Quiver.Binary.write!(b; data = ones(2), row = row)
+end
+Quiver.Binary.close!(b)
+
+################################################
+
+a = Quiver.Binary.File("a")
+b = Quiver.Binary.File("b")
+
+Quiver.Binary.open!(a; mode = 'r')
+Quiver.Binary.open!(b; mode = 'r')
+
+@show c = a + b * 2
+Quiver.save(c, "c")
+
+Quiver.Binary.close!(a)
+Quiver.Binary.close!(b)
+
+################################################
+
+c = Quiver.Binary.open_file("c"; mode = 'r')
+for row in 1:rows
+    @show Quiver.Binary.read(c; row = row)
+end
+Quiver.Binary.close!(c)
+
+return

--- a/generator/Project.toml
+++ b/generator/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-Quiver_jll = "846f1d71-3648-54c4-93dd-5fb4e13f0ad8"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-Clang = "=0.19.0"
+Clang = "=0.19.2"

--- a/generator/generator.bat
+++ b/generator/generator.bat
@@ -2,4 +2,4 @@
 
 SET BASE_PATH=%~dp0
 
-CALL julia --project=%BASE_PATH% %BASE_PATH%\generator.jl
+CALL julia +1.12.5 --project=%BASE_PATH% %BASE_PATH%\generator.jl

--- a/generator/generator.jl
+++ b/generator/generator.jl
@@ -1,17 +1,34 @@
+
 import Pkg
 Pkg.instantiate()
 
 using Clang.Generators
-using Quiver_jll
+using Libdl
 
 cd(@__DIR__)
 
-quiver = Quiver_jll.artifact_dir
-include_dir = joinpath(quiver, "include", "quiver", "c")
+database_dir = joinpath(@__DIR__, "..", "..", "..")
+include_dir = joinpath(database_dir, "include", "quiver", "c")
+
+function libquiver_c_path()
+    dir = if haskey(ENV, "QUIVER_LIB_DIR")
+        ENV["QUIVER_LIB_DIR"]
+    elseif Sys.iswindows()
+        joinpath(database_dir, "build", "bin")
+    else
+        joinpath(database_dir, "build", "lib")
+    end
+    name = Sys.iswindows() ? "libquiver_c.dll" : Sys.isapple() ? "libquiver_c.dylib" : "libquiver_c.so"
+    return joinpath(dir, name)
+end
+
+Libdl.dlopen(libquiver_c_path())
 
 headers = [
-    joinpath(include_dir, header) for
-    header in readdir(include_dir) if endswith(header, ".h") && header != "platform.h"
+    joinpath(root, file)
+    for (root, _, files) in walkdir(include_dir)
+    for file in files
+    if endswith(file, ".h")
 ]
 args = get_default_args()
 options = load_options(joinpath(@__DIR__, "generator.toml"))

--- a/generator/generator.toml
+++ b/generator/generator.toml
@@ -2,10 +2,12 @@
 library_name = "libquiver_c"
 output_file_path = "../src/c_api.jl"
 module_name = "C"
-jll_pkg_name = "Quiver_jll"
+# jll_pkg_name = "Quiver_jll"
 print_using_CEnum = false
-prologue_file_path = "prologue.jl"
-epilogue_file_path = "epilogue.jl"
+auto_mutability = true
+auto_mutability_with_new = false
+prologue_file_path = "./prologue.jl"
+epilogue_file_path = "./epilogue.jl"
 output_ignorelist = [
     "QUIVER_C_API"
 ]

--- a/generator/prologue.jl
+++ b/generator/prologue.jl
@@ -1,4 +1,47 @@
 #! format: off
 
 using CEnum
-import Quiver_jll: libquiver_c
+using Artifacts
+using Libdl
+
+function library_name()
+    if Sys.iswindows()
+        return "libquiver_c.dll"
+    elseif Sys.isapple()
+        return "libquiver_c.dylib"
+    else
+        return "libquiver_c.so"
+    end
+end
+
+# On Windows, DLLs go to bin/; on Linux/macOS, shared libs go to lib/
+function library_dir()
+    if Sys.iswindows()
+        return "bin"
+    else
+        return "lib"
+    end
+end
+
+# Directory holding libquiver_c (and its libquiver dependency). Resolved (at module
+# load) in priority order:
+#   1. QUIVER_LIB_DIR     -- explicit override (CI / advanced users; set before load)
+#   2. the S3 artifact    -- when an Artifacts.toml is present (published Quiver.jl mirror)
+#   3. the in-tree build/ -- monorepo local development
+function quiver_lib_dir()
+    haskey(ENV, "QUIVER_LIB_DIR") && return ENV["QUIVER_LIB_DIR"]
+    artifacts_toml = Artifacts.find_artifacts_toml(@__DIR__)
+    if artifacts_toml !== nothing
+        hash = Artifacts.artifact_hash("quiver", artifacts_toml)
+        hash !== nothing && return joinpath(Artifacts.artifact_path(hash), library_dir())
+    end
+    return joinpath(@__DIR__, "..", "..", "..", "build", library_dir())
+end
+
+const libquiver_c = joinpath(quiver_lib_dir(), library_name())
+
+function __init__()
+    # Pre-load the transitive dependency (libquiver) from the same directory (Windows robustness).
+    dep = Sys.iswindows() ? "libquiver.dll" : Sys.isapple() ? "libquiver.dylib" : "libquiver.so"
+    Libdl.dlopen(joinpath(dirname(libquiver_c), dep); throw_error = false)
+end


### PR DESCRIPTION
Auto-generated mirror from `psrenergy/quiver@v0.8.4`.

- Mirrored the full `bindings/julia/` package (src, test, `.github/`, README, configs)
- Overlaid test schemas from `tests/schemas/`
- Regenerated `Artifacts.toml` (binaries uploaded to S3)
- Version `0.8.4` (from `bindings/julia/Project.toml`)

> Do not hand-edit this repository, it is generated from `psrenergy/quiver/bindings/julia`.